### PR TITLE
refactor: GitHub Actions workflow for release preparation; comment out sections for clarity

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,12 +1,12 @@
----
-name: Prepare release
+# ---
+# name: Prepare release
 
-on:
-  push:
-    branches:
-      - master
+# on:
+#   push:
+#     branches:
+#       - master
 
-jobs:
-  release-please:
-    uses: sencrop/github-workflows/.github/workflows/release-please-v1.yml@master
-    secrets: inherit
+# jobs:
+#   release-please:
+#     uses: .
+#     secrets: inherit


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disables the `prepare_release` GitHub Actions workflow by commenting out all sections.
> 
> - Comments out `name`, `on` (push to `master`), and `jobs` in `.github/workflows/prepare_release.yml`
> - Previous reusable workflow reference (`sencrop/.../release-please-v1.yml@master`) replaced with a commented placeholder (`uses: .`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9a2b0961e90a499c09d84983da8ef6ca9108bab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->